### PR TITLE
change windows press and release send events at windows

### DIFF
--- a/pymouse/__init__.py
+++ b/pymouse/__init__.py
@@ -32,5 +32,6 @@ elif sys.platform == 'win32':
     from windows import PyMouse, PyMouseEvent
 
 else:
+    from . import unix
     from unix import PyMouse, PyMouseEvent
 

--- a/pymouse/base.py
+++ b/pymouse/base.py
@@ -62,7 +62,7 @@ class PyMouseMeta(object):
 
 class PyMouseEventMeta(Thread):
     
-    def __init__(self, capture=False, captureMove):
+    def __init__(self, capture=False, captureMove=False):
         Thread.__init__(self)
         self.daemon = True
         self.capture = capture

--- a/pymouse/base.py
+++ b/pymouse/base.py
@@ -62,10 +62,11 @@ class PyMouseMeta(object):
 
 class PyMouseEventMeta(Thread):
     
-    def __init__(self, capture=False):
+    def __init__(self, capture=False, captureMove):
         Thread.__init__(self)
         self.daemon = True
         self.capture = capture
+        self.captureMove = captureMove
         self.state = True
 
     def stop(self):

--- a/pymouse/base.py
+++ b/pymouse/base.py
@@ -62,11 +62,10 @@ class PyMouseMeta(object):
 
 class PyMouseEventMeta(Thread):
     
-    def __init__(self, capture=False, captureMove=False):
+    def __init__(self, capture=False):
         Thread.__init__(self)
         self.daemon = True
         self.capture = capture
-        self.captureMove = captureMove
         self.state = True
 
     def stop(self):

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -77,15 +77,21 @@ class PyMouse(PyMouseMeta):
         return width, height
 
 class PyMouseEvent(PyMouseEventMeta):
-    def run(self):
-        hm = pyHook.HookManager()
-        hm.MouseAllButtons = self._click
-        hm.MouseMove = self._move
-        hm.HookMouse()
+    def __init__(self):
+        PyMouseEventMeta.__init__(self)
+        self.hm = pyHook.HookManager()
 
+    def run(self):
+        self.hm.MouseAllButtons = self._click
+        self.hm.MouseMove = self._move
+        self.hm.HookMouse()
         while self.state:
             sleep(0.01)
             pythoncom.PumpWaitingMessages()
+          
+    def stop(self):
+        self.hm.UnhookMouse()
+        self.state = False
 
     def _click(self, event):
         x,y = event.Position

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -55,7 +55,7 @@ class PyMouseEvent(PyMouseEventMeta):
         PyMouseEventMeta.__init__(self)
         self.hm = pyHook.HookManager()
 
-def run(self):
+    def run(self):
         self.hm.MouseAllButtons = self._click
         self.hm.MouseMove = self._move
         self.hm.HookMouse()

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -51,15 +51,20 @@ class PyMouse(PyMouseMeta):
         return width, height
 
 class PyMouseEvent(PyMouseEventMeta):
+    def __init__(self):
+        PyMouseEventMeta.__init__(self)
+        self.hm = pyHook.HookManager()
     def run(self):
-        hm = pyHook.HookManager()
         hm.MouseAllButtons = self._click
         hm.MouseMove = self._move
         hm.HookMouse()
-
         while self.state:
             sleep(0.01)
             pythoncom.PumpWaitingMessages()
+
+    def stop(self):
+        self.hm.UnhookMouse()
+        self.state = False
 
     def _click(self, event):
         x,y = event.Position

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -113,4 +113,4 @@ class PyMouseEvent(PyMouseEventMeta):
     def _move(self, event):
         x,y = event.Position
         self.move(x, y)
-        return not self.capture
+        return not self.captureMove

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -15,7 +15,7 @@
 #   limitations under the License.
 
 from ctypes import *
-from win32api import GetSystemMetrics
+import win32api,win32con
 from base import PyMouseMeta, PyMouseEventMeta
 import pythoncom, pyHook
 from time import sleep

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -54,10 +54,11 @@ class PyMouseEvent(PyMouseEventMeta):
     def __init__(self):
         PyMouseEventMeta.__init__(self)
         self.hm = pyHook.HookManager()
-    def run(self):
-        hm.MouseAllButtons = self._click
-        hm.MouseMove = self._move
-        hm.HookMouse()
+
+def run(self):
+        self.hm.MouseAllButtons = self._click
+        self.hm.MouseMove = self._move
+        self.hm.HookMouse()
         while self.state:
             sleep(0.01)
             pythoncom.PumpWaitingMessages()


### PR DESCRIPTION
i found that the press with the old macro make a click action, so i can't move icons on desktop.

I found a simple method to make this actions and change the release and press method on windows.

Also add UnhookMouse and change the hm var to the instance creation class, becouse if not  we can call the hm.UnhookMouse at stop method.
