### PR TITLE
Proper button naming + more button support on unix

### DIFF
--- a/pymouse/__init__.py
+++ b/pymouse/__init__.py
@@ -34,3 +34,4 @@ elif sys.platform == 'win32':
 else:
     from unix import PyMouse, PyMouseEvent
 
+from base import MouseButtons

--- a/pymouse/base.py
+++ b/pymouse/base.py
@@ -22,6 +22,22 @@ See http://github.com/pepijndevos/PyMouse for more information.
 
 from threading import Thread
 
+
+class MouseButtons:
+    
+    BUTTON_LEFT = 1
+    BUTTON_MIDDLE = 2
+    BUTTON_RIGHT = 3
+    BUTTON_SCROLL_UP = 4
+    BUTTON_SCROLL_DOWN = 5
+    BUTTON_SCROLL_LEFT = 6
+    BUTTON_SCROLL_RIGHT = 7
+    BUTTON_THUMB_BACK = 8
+    BUTTON_THUMB_FORWARD = 9
+    
+     
+
+
 class PyMouseMeta(object):
 
     def press(self, x, y, button = 1):

--- a/pymouse/mac.py
+++ b/pymouse/mac.py
@@ -57,7 +57,7 @@ def get_event_code(button_code, state):
     
     # Mac only supports Left, Middle and Right buttons
     if button_code not in (1, 2, 3):
-        raise ValueError("Event code not recognized!")
+        raise ValueError("Button not supported")
     
     
     if state:

--- a/pymouse/mac.py
+++ b/pymouse/mac.py
@@ -21,13 +21,44 @@ from base import PyMouseMeta, PyMouseEventMeta
 pressID = [None, kCGEventLeftMouseDown, kCGEventRightMouseDown, kCGEventOtherMouseDown]
 releaseID = [None, kCGEventLeftMouseUp, kCGEventRightMouseUp, kCGEventOtherMouseUp]
 
+
+
+def get_button_code(event_message):
+    """ Platform specific ! """
+    
+    if type in pressID:
+        code = pressID.index(type)
+        state = True
+    elif type in releaseID:
+        code = releaseID.index(type)
+        state = False
+    else:
+        code = None
+        state = False
+            
+    return (code, state)
+
+
+def get_event_code(button_code, state):
+    """ Platform specific ! """
+    
+    if state:
+        code = pressID[button_code]
+        
+    else:
+        code = releaseID[button_code]
+        
+    return code
+
+
+
 class PyMouse(PyMouseMeta):
-    def press(self, x, y, button = 1):
-        event = CGEventCreateMouseEvent(None, pressID[button], (x, y), button - 1)
+    def press(self, x, y, button=1):
+        event = CGEventCreateMouseEvent(None, get_event_code(button, True), (x, y), button - 1)
         CGEventPost(kCGHIDEventTap, event)
 
-    def release(self, x, y, button = 1):
-        event = CGEventCreateMouseEvent(None, releaseID[button], (x, y), button - 1)
+    def release(self, x, y, button=1):
+        event = CGEventCreateMouseEvent(None, get_event_code(button, False), (x, y), button - 1)
         CGEventPost(kCGHIDEventTap, event)
 
     def move(self, x, y):
@@ -48,12 +79,12 @@ class PyMouseEvent(PyMouseEventMeta):
             kCGSessionEventTap,
             kCGHeadInsertEventTap,
             kCGEventTapOptionDefault,
-            CGEventMaskBit(kCGEventMouseMoved) |
-            CGEventMaskBit(kCGEventLeftMouseDown) |
-            CGEventMaskBit(kCGEventLeftMouseUp) |
-            CGEventMaskBit(kCGEventRightMouseDown) |
-            CGEventMaskBit(kCGEventRightMouseUp) |
-            CGEventMaskBit(kCGEventOtherMouseDown) |
+            CGEventMaskBit(kCGEventMouseMoved) | 
+            CGEventMaskBit(kCGEventLeftMouseDown) | 
+            CGEventMaskBit(kCGEventLeftMouseUp) | 
+            CGEventMaskBit(kCGEventRightMouseDown) | 
+            CGEventMaskBit(kCGEventRightMouseUp) | 
+            CGEventMaskBit(kCGEventOtherMouseDown) | 
             CGEventMaskBit(kCGEventOtherMouseUp),
             self.handler,
             None)
@@ -68,10 +99,11 @@ class PyMouseEvent(PyMouseEventMeta):
 
     def handler(self, proxy, type, event, refcon):
         (x, y) = CGEventGetLocation(event)
-        if type in pressID:
-            self.click(x, y, pressID.index(type), True)
-        elif type in releaseID:
-            self.click(x, y, releaseID.index(type), False)
+        
+        (code, state) = get_button_code(type)
+        
+        if code is not None:
+            self.click(x, y, code, state)
         else:
             self.move(x, y)
         

--- a/pymouse/mac.py
+++ b/pymouse/mac.py
@@ -16,7 +16,7 @@
 
 from Quartz import *
 from AppKit import NSEvent
-from base import PyMouseMeta, PyMouseEventMeta
+from base import PyMouseMeta, PyMouseEventMeta, MouseButtons
 
 pressID = [None, kCGEventLeftMouseDown, kCGEventRightMouseDown, kCGEventOtherMouseDown]
 releaseID = [None, kCGEventLeftMouseUp, kCGEventRightMouseUp, kCGEventOtherMouseUp]
@@ -26,11 +26,24 @@ releaseID = [None, kCGEventLeftMouseUp, kCGEventRightMouseUp, kCGEventOtherMouse
 def get_button_code(event_message):
     """ Platform specific ! """
     
-    if type in pressID:
-        code = pressID.index(type)
+    
+    if event_message == kCGEventLeftMouseDown:
+        code = MouseButtons.BUTTON_LEFT
         state = True
-    elif type in releaseID:
-        code = releaseID.index(type)
+    elif event_message == kCGEventLeftMouseUp:
+        code = MouseButtons.BUTTON_LEFT
+        state = False
+    elif event_message == kCGEventRightMouseDown:
+        code = MouseButtons.BUTTON_RIGHT
+        state = True
+    elif event_message == kCGEventRightMouseUp:
+        code = MouseButtons.BUTTON_RIGHT
+        state = False
+    elif event_message == kCGEventOtherMouseDown:
+        code = MouseButtons.BUTTON_MIDDLE
+        state = True
+    elif event_message == kCGEventOtherMouseUp:
+        code = MouseButtons.BUTTON_MIDDLE
         state = False
     else:
         code = None
@@ -42,9 +55,13 @@ def get_button_code(event_message):
 def get_event_code(button_code, state):
     """ Platform specific ! """
     
+    # Mac only supports Left, Middle and Right buttons
+    if button_code not in (1, 2, 3):
+        raise ValueError("Event code not recognized!")
+    
+    
     if state:
         code = pressID[button_code]
-        
     else:
         code = releaseID[button_code]
         

--- a/pymouse/unix.py
+++ b/pymouse/unix.py
@@ -123,10 +123,8 @@ class PyMouseEvent(PyMouseEventMeta):
 
             
             if event.type == X.ButtonPress:
-                print event.detail
                 self.click(event.root_x, event.root_y, get_button_code(event.detail), True)
             elif event.type == X.ButtonRelease:
-                print event.detail
                 self.click(event.root_x, event.root_y, get_button_code(event.detail), False)
             else:
                 self.move(event.root_x, event.root_y)

--- a/pymouse/unix.py
+++ b/pymouse/unix.py
@@ -20,8 +20,36 @@ from Xlib.ext.xtest import fake_input
 from Xlib.ext import record
 from Xlib.protocol import rq
 
-from base import PyMouseMeta, PyMouseEventMeta
+from base import PyMouseMeta, PyMouseEventMeta, MouseButtons
 
+
+def get_button_code(event_message):
+    """ Platform specific ! """
+    
+    try:
+        code = (None, 
+                MouseButtons.BUTTON_LEFT,
+                MouseButtons.BUTTON_MIDDLE, 
+                MouseButtons.BUTTON_RIGHT,
+                MouseButtons.BUTTON_SCROLL_UP,
+                MouseButtons.BUTTON_SCROLL_DOWN,
+                MouseButtons.BUTTON_SCROLL_LEFT,
+                MouseButtons.BUTTON_SCROLL_RIGHT,
+                MouseButtons.BUTTON_THUMB_BACK,
+                MouseButtons.BUTTON_THUMB_FORWARD)[event_message]
+                
+    except IndexError:
+        code = None
+        
+    return code
+
+
+def get_event_code(button_code):
+    """ Platform specific ! """
+    
+    return button_code
+    
+    
 
 class PyMouse(PyMouseMeta):
     def __init__(self):
@@ -31,12 +59,12 @@ class PyMouse(PyMouseMeta):
 
     def press(self, x, y, button = 1):
         self.move(x, y)
-        fake_input(self.display, X.ButtonPress, [None, 1, 3, 2, 4, 5][button])
+        fake_input(self.display, X.ButtonPress, get_event_code(button))
         self.display.sync()
 
     def release(self, x, y, button = 1):
         self.move(x, y)
-        fake_input(self.display, X.ButtonRelease, [None, 1, 3, 2, 4, 5][button])
+        fake_input(self.display, X.ButtonRelease, get_event_code(button))
         self.display.sync()
 
     def move(self, x, y):
@@ -92,10 +120,14 @@ class PyMouseEvent(PyMouseEventMeta):
         while len(data):
             event, data = rq.EventField(None).parse_binary_value(data, self.display.display, None, None)
 
+
+            
             if event.type == X.ButtonPress:
-                self.click(event.root_x, event.root_y, (None, 1, 3, 2, 3, 3, 3)[event.detail], True)
+                print event.detail
+                self.click(event.root_x, event.root_y, get_button_code(event.detail), True)
             elif event.type == X.ButtonRelease:
-                self.click(event.root_x, event.root_y, (None, 1, 3, 2, 3, 3, 3)[event.detail], False)
+                print event.detail
+                self.click(event.root_x, event.root_y, get_button_code(event.detail), False)
             else:
                 self.move(event.root_x, event.root_y)
 

--- a/pymouse/unix.py
+++ b/pymouse/unix.py
@@ -39,7 +39,7 @@ def get_button_code(event_message):
                 MouseButtons.BUTTON_THUMB_FORWARD)[event_message]
                 
     except IndexError:
-        code = None
+        raise ValueError("Button not supported")
         
     return code
 

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -53,7 +53,7 @@ def get_event_code(button_code, state):
     
     # swap button 2 and 3, because Windows uses 3 for middle button and 2 for right button
     if button_code == 2:
-        button_code == 3
+        button_code = 3
     elif button_code == 3:
         button_code = 2
     

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -44,7 +44,7 @@ def get_button_code(event_message):
     return code
 
 
-def get_event_code(button_code):
+def get_event_code(button_code, state):
     """ Platform specific ! """
     
     # Windows only supports Left, Middle and Right buttons
@@ -56,8 +56,12 @@ def get_event_code(button_code):
         button_code == 3
     elif button_code == 3:
         button_code = 2
+    
+    if state:
+        code = 2 ** ((2 * button_code) - 1)
+    else:
+        code = 2 ** ((2 * button_code))
         
-    code = 2 ** ((2 * button_code) - 1)
     
     return code
     
@@ -72,12 +76,12 @@ class PyMouse(PyMouseMeta):
     """MOUSEEVENTF_(button and action) constants 
     are defined at win32con, buttonAction is that value"""
     def press(self, x, y, button=1):
-        buttonAction = get_event_code(button)
+        buttonAction = get_event_code(button, True)
         self.move(x, y)
         win32api.mouse_event(buttonAction, x, y)
      
     def release(self, x, y, button=1):
-        buttonAction = get_event_code(button)
+        buttonAction = get_event_code(button, False)
         self.move(x, y)
         win32api.mouse_event(buttonAction, x, y)
 

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -49,7 +49,7 @@ def get_event_code(button_code, state):
     
     # Windows only supports Left, Middle and Right buttons
     if button_code not in (1, 2, 3):
-        raise ValueError("Event code not recognized!")
+        raise ValueError("Button not supported")
     
     # swap button 2 and 3, because Windows uses 3 for middle button and 2 for right button
     if button_code == 2:


### PR DESCRIPTION
I have a mouse with thumb buttons, they when pressed they raise errors.

I fixed it in reply to: https://github.com/pepijndevos/PyMouse/commit/43b69c8e83e8b7000ad05d034826ea8051f9aa42#commitcomment-295776

On unix systems all\* buttons are now supported

tested on linux and windows, not tested on mac!

*) Left, middle, right, scroll-up -down -left -right and thumb-forward -backward
