### PR TITLE
Avoid Quartz lazyloader `from Quartz import *` bug

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,2 +1,1 @@
-The goal of PyMouse is to have a cross-platform way to control the mouse.
-PyMouse should work on Windows, Mac and any Unix that has xlib.
+PyMouse has been merged into PyUserInput at https://github.com/SavinaRoja/PyUserInput

--- a/pymouse/mac.py
+++ b/pymouse/mac.py
@@ -14,60 +14,60 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from Quartz import *
+import Quartz
 from AppKit import NSEvent
 from base import PyMouseMeta, PyMouseEventMeta
 
-pressID = [None, kCGEventLeftMouseDown, kCGEventRightMouseDown, kCGEventOtherMouseDown]
-releaseID = [None, kCGEventLeftMouseUp, kCGEventRightMouseUp, kCGEventOtherMouseUp]
+pressID = [None, Quartz.kCGEventLeftMouseDown, Quartz.kCGEventRightMouseDown, Quartz.kCGEventOtherMouseDown]
+releaseID = [None, Quartz.kCGEventLeftMouseUp, Quartz.kCGEventRightMouseUp, Quartz.kCGEventOtherMouseUp]
 
 class PyMouse(PyMouseMeta):
     def press(self, x, y, button = 1):
-        event = CGEventCreateMouseEvent(None, pressID[button], (x, y), button - 1)
-        CGEventPost(kCGHIDEventTap, event)
+        event = Quartz.CGEventCreateMouseEvent(None, pressID[button], (x, y), button - 1)
+        Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
 
     def release(self, x, y, button = 1):
-        event = CGEventCreateMouseEvent(None, releaseID[button], (x, y), button - 1)
-        CGEventPost(kCGHIDEventTap, event)
+        event = Quartz.CGEventCreateMouseEvent(None, releaseID[button], (x, y), button - 1)
+        Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
 
     def move(self, x, y):
-        move = CGEventCreateMouseEvent(None, kCGEventMouseMoved, (x, y), 0)
-        CGEventPost(kCGHIDEventTap, move)
+        move = Quartz.CGEventCreateMouseEvent(None, Quartz.kCGEventMouseMoved, (x, y), 0)
+        Quartz.CGEventPost(Quartz.kCGHIDEventTap, move)
         
 
     def position(self):
         loc = NSEvent.mouseLocation()
-        return loc.x, CGDisplayPixelsHigh(0) - loc.y
+        return loc.x, Quartz.CGDisplayPixelsHigh(0) - loc.y
 
     def screen_size(self):
-        return CGDisplayPixelsWide(0), CGDisplayPixelsHigh(0)
+        return Quartz.CGDisplayPixelsWide(0), Quartz.CGDisplayPixelsHigh(0)
 
 class PyMouseEvent(PyMouseEventMeta):
     def run(self):
-        tap = CGEventTapCreate(
-            kCGSessionEventTap,
-            kCGHeadInsertEventTap,
-            kCGEventTapOptionDefault,
-            CGEventMaskBit(kCGEventMouseMoved) |
-            CGEventMaskBit(kCGEventLeftMouseDown) |
-            CGEventMaskBit(kCGEventLeftMouseUp) |
-            CGEventMaskBit(kCGEventRightMouseDown) |
-            CGEventMaskBit(kCGEventRightMouseUp) |
-            CGEventMaskBit(kCGEventOtherMouseDown) |
-            CGEventMaskBit(kCGEventOtherMouseUp),
+        tap = Quartz.CGEventTapCreate(
+            Quartz.kCGSessionEventTap,
+            Quartz.kCGHeadInsertEventTap,
+            Quartz.kCGEventTapOptionDefault,
+            Quartz.CGEventMaskBit(Quartz.kCGEventMouseMoved) |
+            Quartz.CGEventMaskBit(Quartz.kCGEventLeftMouseDown) |
+            Quartz.CGEventMaskBit(Quartz.kCGEventLeftMouseUp) |
+            Quartz.CGEventMaskBit(Quartz.kCGEventRightMouseDown) |
+            Quartz.CGEventMaskBit(Quartz.kCGEventRightMouseUp) |
+            Quartz.CGEventMaskBit(Quartz.kCGEventOtherMouseDown) |
+            Quartz.CGEventMaskBit(Quartz.kCGEventOtherMouseUp),
             self.handler,
             None)
 
-        loopsource = CFMachPortCreateRunLoopSource(None, tap, 0)
-        loop = CFRunLoopGetCurrent()
-        CFRunLoopAddSource(loop, loopsource, kCFRunLoopDefaultMode)
-        CGEventTapEnable(tap, True)
+        loopsource = Quartz.CFMachPortCreateRunLoopSource(None, tap, 0)
+        loop = Quartz.CFRunLoopGetCurrent()
+        Quartz.CFRunLoopAddSource(loop, loopsource, Quartz.kCFRunLoopDefaultMode)
+        Quartz.CGEventTapEnable(tap, True)
 
         while self.state:
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 5, False)
+            Quartz.CFRunLoopRunInMode(Quartz.kCFRunLoopDefaultMode, 5, False)
 
     def handler(self, proxy, type, event, refcon):
-        (x, y) = CGEventGetLocation(event)
+        (x, y) = Quartz.CGEventGetLocation(event)
         if type in pressID:
             self.click(x, y, pressID.index(type), True)
         elif type in releaseID:
@@ -76,6 +76,6 @@ class PyMouseEvent(PyMouseEventMeta):
             self.move(x, y)
         
         if self.capture:
-            CGEventSetType(event, kCGEventNull)
+            Quartz.CGEventSetType(event, Quartz.kCGEventNull)
 
         return event

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -46,8 +46,8 @@ class PyMouse(PyMouseMeta):
         return pt.x, pt.y
 
     def screen_size(self):
-        width = GetSystemMetrics(0)
-        height = GetSystemMetrics(1)
+        width = windll.user32.GetSystemMetrics(0)
+        height = windll.user32.GetSystemMetrics(1)
         return width, height
 
 class PyMouseEvent(PyMouseEventMeta):

--- a/tests/test_import_times.py
+++ b/tests/test_import_times.py
@@ -1,0 +1,38 @@
+# coding=utf8
+#   Copyright 2014 Christopher H. Casebeer
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+'''
+Tests that import time for pymouse is not unreasonably long. 
+
+This catches the slow-import-of-Quartz on Mac OS X due to pyobjc's slow 
+behavior when import via from ... import *. 
+'''
+
+import contextlib
+import time
+
+@contextlib.contextmanager
+def check_execution_time(description, max_seconds):
+	start_time = time.time()
+	yield
+	end_time = time.time()
+	execution_time = end_time - start_time
+	if execution_time > max_seconds:
+		raise Exception("Took too long to complete %s" % description)
+
+def test_pymouse_import_time():
+	with check_execution_time("importing pymouse", max_seconds=3):
+		import pymouse
+

--- a/tests/test_import_times.py
+++ b/tests/test_import_times.py
@@ -23,6 +23,8 @@ behavior when import via from ... import *.
 import contextlib
 import time
 
+from nose import SkipTest
+
 @contextlib.contextmanager
 def check_execution_time(description, max_seconds):
 	start_time = time.time()
@@ -33,6 +35,8 @@ def check_execution_time(description, max_seconds):
 		raise Exception("Took too long to complete %s" % description)
 
 def test_pymouse_import_time():
+	# skip this test by default – call nosetests with --no-skip to enable
+	raise SkipTest()
 	with check_execution_time("importing pymouse", max_seconds=3):
 		import pymouse
 


### PR DESCRIPTION
I've been having a problem with very long import times/hanging on import. 

Specifically, 

```
import pymouse
```

hangs for in excess of 15 seconds on Mac OS X 10.9.3/Python 2.7.5 with pyobjc v2.5.1.

I've traced the issue back to the pyobjc project, which has a bug discussion containing this message:

> If you are only using framework wrappers: make sure you do not use "from Foundation  import ", use "import Foundation" or "from Foundation import NSObject" instead.  Someone recently noticed that the "from ... import " form is currently much slower than  it used to be, due to the way the PyObjC lazy loader is implemented. I'm working on a fix for that, but even with the fix explicit imports will be better because they perform  less form (because explicit imports don't have to resolve the symbols you don't use).

https://bitbucket.org/ronaldoussoren/pyobjc/issue/2/faster-metadata-support#comment-5204985

The pymouse/mac.py module uses exactly this `from Quartz import *` import style. 

Changing this to `import Quartz` and fixing the references to Quartz objects solves the import time issues. 

I've also added a unit test that checks the import time for pymouse. 
### Reproducing the bug
#### Environment
- Mac OS X 10.9.3 Mavericks
- 1.6 GHz Core 2 Duo, 8 GB RAM, SSD
- Python 2.7.5
- pyobjc-core 2.5.1 
- PyMouse 1.0 (from PyPi or git b0cc56c)
#### Steps
1. import the pymouse module.

You should observe at least a 15 second hang with no output or other response. For example:

```
print "About to import pymouse"
import pymouse
print "This will print at least 15 seconds later"
```
### Results

Before the patch, at version 1.0/b0cc56c:

```
$ time python -m pymouse
...
real    0m16.040s
user    0m14.322s
sys 0m0.194s
```

After changing to `import Quartz`:

```
$ time python -m pymouse
...    
real    0m0.558s
user    0m0.390s
sys 0m0.087s
```

**n.b. I've issued substantially this same Pull Request to the PyUserinput project as well.**
